### PR TITLE
Fix API v3 requests by adding X-Client header

### DIFF
--- a/habitrpg.el
+++ b/habitrpg.el
@@ -1,4 +1,4 @@
-;;; habitrpg.el --- org-mode interface to habitrpg
+;;; habitrpg.el --- org-mode interface to habitrpg  -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2013
 
@@ -1261,6 +1261,7 @@ TITLE is the displayed title of the section."
  		    "Stable:" 'habitrpg-wash-tasks nil))
 
 (defvar habitrpg-indentation-level 1)
+(defvar section-title nil "Dynamic variable holding the current section title.")
 
 (defun habitrpg-wash-tasks ()
   (habitrpg-wash-sequence #'habitrpg-wash-task))
@@ -1407,7 +1408,7 @@ With a prefix argument, kill the buffer instead."
 (defun habitrpg-setup ()
   (save-excursion (save-window-excursion
 		    (if (string= major-mode 'org-agenda-mode) (org-agenda-switch-to))
-		    (lexical-let* ((in-habit (org-entry-get-with-inheritance "IN_HABITRPG")))
+		    (let* ((in-habit (org-entry-get-with-inheritance "IN_HABITRPG")))
 		      (cond
 		       ((string= in-habit "unknown")
 			(habitrpg-add))
@@ -1443,25 +1444,25 @@ there.  If its state is DONE, update."
   (habitrpg-do-backlog)
   (save-excursion (save-window-excursion
 		    (if (string= major-mode 'org-agenda-mode) (org-agenda-switch-to))
-		    (lexical-let* ((task (nth 4 (org-heading-components)))
-				   (state (nth 2 (org-heading-components)))
-				   (in-habit (org-entry-get-with-inheritance "IN_HABITRPG"))
-				   (last-done-string (if (org-is-habit-p (point))
-							 (car (sort 
-							       (org-habit-done-dates
-								(org-habit-parse-todo))
-							       '>)))
-						     nil)
-				   (last-done-day 
-				    (if (and (member "hrpgdaily" (org-get-tags-at))
-					     last-done-string)
-					(butlast
-					 (nthcdr 3
-						 (decode-time 
-						  (days-to-time last-done-string
-								))) 4)
-				      nil))
-				   type)
+		    (let* ((task (nth 4 (org-heading-components)))
+			   (state (nth 2 (org-heading-components)))
+			   (in-habit (org-entry-get-with-inheritance "IN_HABITRPG"))
+			   (last-done-string (if (org-is-habit-p (point))
+						 (car (sort
+						       (org-habit-done-dates
+							(org-habit-parse-todo))
+						       '>))
+					       nil))
+			   (last-done-day
+			    (if (and (member "hrpgdaily" (org-get-tags-at))
+				     last-done-string)
+				(butlast
+				 (nthcdr 3
+					 (decode-time
+					  (days-to-time last-done-string
+							))) 4)
+			      nil))
+			   type)
 
 		      (habitrpg-get-id task
 				       (lambda (id)
@@ -1515,11 +1516,11 @@ there.  If its state is DONE, update."
 	       (message "Task created.")))))
 
 (defun habitrpg-new-task (&optional type)
-  (lexical-let* ((type (or type "todo"))
-		 (task (read-from-minibuffer "Task Name: "))
-		 (notes (read-from-minibuffer "Notes: "))
-		 (value (when (string= type "reward") (read-from-minibuffer "Cost: ")))
-		 (p (point)))
+  (let* ((type (or type "todo"))
+	 (task (read-from-minibuffer "Task Name: "))
+	 (notes (read-from-minibuffer "Notes: "))
+	 (value (when (string= type "reward") (read-from-minibuffer "Cost: ")))
+	 (p (point)))
     (if (string= type 'reward)
 	(habitrpg-create type task notes value)
       (habitrpg-create type task notes)
@@ -1537,29 +1538,29 @@ there.  If its state is DONE, update."
      :headers (habitrpg-headers '(("Content-Type" . "application/json")
 				  ("Content-Length" . 0)))
      :parser 'json-read
-     :error  (function* (lambda (&key error-thrown &allow-other-keys&rest _)
-			  (message "HabitRPG: Error in getting id for task [%s]" t))))
+     :error  (cl-function (lambda (&key error-thrown &allow-other-keys)
+			    (message "HabitRPG: Error in getting id for task [%s]" t))))
     (deferred:nextc it
-      `(lambda (response)
+      (lambda (response)
 	(if (request-response-error-thrown response)
 	    (progn
 	      (message "HabitRPG: Error reviving")))))))
 
 (defun habitrpg-get-id (task func)
-  (lexical-let ((ts task) (func func))
+  (let ((ts task) (func func))
     (deferred:$
       (request-deferred
        (concat habitrpg-api-url habitrpg-api-usertask-path)
        :headers (habitrpg-headers '(("Accept" . "application/json")))
        :parser 'json-read
-       :error  (function* (lambda (&key error-thrown &allow-other-keys&rest _)
-			    (message "HabitRPG: Error in getting id for task [%s]" ts))))
+       :error  (cl-function (lambda (&key error-thrown &allow-other-keys)
+			      (message "HabitRPG: Error in getting id for task [%s]" ts))))
       (deferred:nextc it
-	`(lambda (response)
+	(lambda (response)
 	  (if (request-response-error-thrown response)
 	      (progn
-		(message "HabitRPG: Error in getting id for task [%s]" ,ts)
-		(setq hrpg-to-add (cl-adjoin ,ts hrpg-to-add)))
+		(message "HabitRPG: Error in getting id for task [%s]" ts)
+		(setq hrpg-to-add (cl-adjoin ts hrpg-to-add)))
 	    (let* ((data (assoc-default 'data (request-response-data response)))
 		   (tasks (append data nil))
 		   (names (mapcar
@@ -1575,7 +1576,7 @@ there.  If its state is DONE, update."
 					(assoc-default 'type task-id) "habit"))
 				      (string= (assoc-default
 						'text task-id)
-					       ,ts))
+					       ts))
 				 (list (assoc-default 'text task-id) (assoc-default 'id task-id))))) tasks))
 		   ;; Completed tasks should not be upvoted, so
 		   ;; we should gather a list of those tasks and
@@ -1586,47 +1587,47 @@ there.  If its state is DONE, update."
 			    (lambda (task-id)
 			      (let* ((name (assoc-default 'text task-id)))
 				(when (not (assoc-default name names))
-				  (list name (car task-id))))) tasks)))
-	      (if (assoc-default ,ts cnames)
+				  (list name (car task-id))))) tasks))
+		   id)
+	      (if (assoc-default ts cnames)
 		  (progn
 		    (setq id "completed")
-		    (message "Task %S has already been done!" ,ts))
-		(setq id (car (assoc-default ,ts names)))
-		(message "Got id %S for task %S" id ,ts))
-	      (funcall ,func id))))))))
+		    (message "Task %S has already been done!" ts))
+		(setq id (car (assoc-default ts names)))
+		(message "Got id %S for task %S" id ts))
+	      (funcall func id))))))))
 
 
 (defun habitrpg-upvote (id &optional task type text direction)
-  (lexical-let ((direction direction) (task task) (type type))
-    (request
-     (if (string= type "store")
-	 (concat habitrpg-api-url habitrpg-api-inventory-path "/buy/" id "/")
-       (concat habitrpg-api-url habitrpg-api-tasks-path "/" id "/score/"
-	       (unless direction "up") direction))
-     :type "POST"
-     :headers (habitrpg-headers '(("Content-Type" . "application/json")
-				  ("Content-Length" . 0)))
-     :parser 'json-read
-     :success (function* (lambda (&key data &allow-other-keys)
-			   (if hrpg-status-to-file
-			       (with-temp-file "~/tmp/hrpg-status"
-				 (let* ((exp (assoc-default 'exp data))
-					(gp (assoc-default 'gp data))
-					(hp (assoc-default 'hp data))
-					(lvl (assoc-default 'lvl data)))
-				   (insert (concat "exp: " (number-to-string (truncate exp))
-						   " gp: " (number-to-string (truncate gp))
-						   " hp: " (number-to-string (truncate hp))
-						   " lvl: " (number-to-string (truncate lvl)))))))
-			   (cond ((or (string= type "reward") (string= type "store"))
-				  (message "Purchased %s" id))
-				 ((string= direction "down")
-				  (message "Health lost for habit %s" task))
-				 ((not (string= direction "up"))
-				  (message "Experience gained!")))))
-     :error (function* (lambda (&key error-thrown &allow-other-keys&rest _)
+  (request
+   (if (string= type "store")
+       (concat habitrpg-api-url habitrpg-api-inventory-path "/buy/" id "/")
+     (concat habitrpg-api-url habitrpg-api-tasks-path "/" id "/score/"
+	     (unless direction "up") direction))
+   :type "POST"
+   :headers (habitrpg-headers '(("Content-Type" . "application/json")
+				("Content-Length" . 0)))
+   :parser 'json-read
+   :success (function* (lambda (&key data &allow-other-keys)
+			 (if hrpg-status-to-file
+			     (with-temp-file "~/tmp/hrpg-status"
+			       (let* ((exp (assoc-default 'exp data))
+				      (gp (assoc-default 'gp data))
+				      (hp (assoc-default 'hp data))
+				      (lvl (assoc-default 'lvl data)))
+				 (insert (concat "exp: " (number-to-string (truncate exp))
+						 " gp: " (number-to-string (truncate gp))
+						 " hp: " (number-to-string (truncate hp))
+						 " lvl: " (number-to-string (truncate lvl)))))))
+			 (cond ((or (string= type "reward") (string= type "store"))
+				(message "Purchased %s" id))
+			       ((string= direction "down")
+				(message "Health lost for habit %s" task))
+			       ((not (string= direction "up"))
+				(message "Experience gained!")))))
+   :error (cl-function (lambda (&key error-thrown &allow-other-keys)
 			 (message "HabitRPG: Error in completing [%s]" id)
-			 (setq hrpg-to-upvote-ids (cl-adjoin id hrpg-to-upvote-ids)))))))
+			 (setq hrpg-to-upvote-ids (cl-adjoin id hrpg-to-upvote-ids))))))
 
 
 (defun habitrpg-get-id-at-point ()
@@ -1764,14 +1765,14 @@ Continuously upvote habits associated with the currently clocking task, based on
     (save-excursion (save-window-excursion
 		      (with-current-buffer "*habitrpg:status*"
 			(setq header-line-format nil)))))
-  (lexical-let* ((tags (org-get-tags-at))
-		 (habit (car (intersection tags hrpg-tags-list :test 'equal)))
-		 (bad (unless (not hrpg-bad-tags-list)
-			(mapcar
-			 (lambda (tag)
-			   (assoc tag hrpg-bad-tags-list))
-			 tags)))
-		 (badhabit (car (remove nil bad))))
+  (let* ((tags (org-get-tags-at))
+	 (habit (car (intersection tags hrpg-tags-list :test 'equal)))
+	 (bad (unless (not hrpg-bad-tags-list)
+		(mapcar
+		 (lambda (tag)
+		   (assoc tag hrpg-bad-tags-list))
+		 tags)))
+	 (badhabit (car (remove nil bad))))
     (when tags
       (cond (habit
 	     (habitrpg-get-id habit

--- a/habitrpg.el
+++ b/habitrpg.el
@@ -144,6 +144,21 @@
   "API Inventory Path"
   :group 'habitrpg)
 
+(defcustom habitrpg-api-client "habitrpg"
+  "API client name used in the X-Client header."
+  :group 'habitrpg
+  :type 'string)
+
+(defun habitrpg-headers (&optional extra-headers)
+  "Generate the HTTP headers required for Habitica API v3 requests.
+Includes X-API-User, X-API-Key, and X-Client. EXTRA-HEADERS
+will be prepended to the list."
+  (append
+   extra-headers
+   `(("X-API-User" . ,(or habitrpg-api-user ""))
+     ("X-API-Key" . ,(or habitrpg-api-token ""))
+     ("X-Client" . ,(concat (or habitrpg-api-user "") "-" habitrpg-api-client)))))
+
 (cl-eval-when (load eval)
   (defalias 'habitrpg-set-variable-and-refresh 'set-default))
 
@@ -371,9 +386,7 @@ The function is given one argument, the status buffer."
        (concat habitrpg-api-url habitrpg-api-user-path)
        :type "GET"
        :parser 'json-read
-       :headers `(("Accept" . "application/json")
-		  ("X-API-User" . ,habitrpg-api-user)
-		  ("X-API-Key" . ,habitrpg-api-token))
+       :headers (habitrpg-headers '(("Accept" . "application/json")))
        :sync t
        :success (function*
 		 (lambda (&key data &allow-other-keys)
@@ -1121,9 +1134,7 @@ TITLE is the displayed title of the section."
 		    (concat habitrpg-api-url habitrpg-api-usertask-path)
 		    :type "GET"
 		    :parser 'json-read
-		    :headers `(("Accept" . "application/json")
-			       ("X-API-User" . ,habitrpg-api-user)
-			       ("X-API-Key" . ,habitrpg-api-token))
+		    :headers (habitrpg-headers '(("Accept" . "application/json")))
 		    :sync t
 		    :success (function*
 			      (lambda (&key data &allow-other-keys)
@@ -1177,9 +1188,7 @@ TITLE is the displayed title of the section."
 		    (concat habitrpg-api-url habitrpg-api-user-path)
 		    :type "GET"
 		    :parser 'json-read
-		    :headers `(("Accept" . "application/json")
-			       ("X-API-User" . ,habitrpg-api-user)
-			       ("X-API-Key" . ,habitrpg-api-token))
+		    :headers (habitrpg-headers '(("Accept" . "application/json")))
 		    :sync t
 		    :success (function*
 			      (lambda (&key data &allow-other-keys)
@@ -1209,9 +1218,7 @@ TITLE is the displayed title of the section."
   		    (concat habitrpg-api-url habitrpg-api-inventory-path "/buy")
   		    :type "GET"
   		    :parser 'json-read
-  		    :headers `(("Accept" . "application/json")
-  			       ("X-API-User" . ,habitrpg-api-user)
-  			       ("X-API-Key" . ,habitrpg-api-token))
+  		    :headers (habitrpg-headers '(("Accept" . "application/json")))
   		    :sync t
   		    :success (function*
   			      (lambda (&key data &allow-other-keys)
@@ -1490,9 +1497,7 @@ there.  If its state is DONE, update."
   (request
    (concat habitrpg-api-url habitrpg-api-usertask-path "/")
    :type "POST"
-   :headers `(("Accept" . "application/json")
-	      ("X-API-User" . ,habitrpg-api-user)
-	      ("X-API-Key" . ,habitrpg-api-token))
+   :headers (habitrpg-headers '(("Accept" . "application/json")))
    :data `(("type" . ,type)
 	   ("text" . ,task)
 	   ("notes" . ,text)
@@ -1522,10 +1527,8 @@ there.  If its state is DONE, update."
     (request-deferred
      (concat habitrpg-api-url habitrpg-api-user-path "/revive")
      :type "POST"
-     :headers `(("Content-Type" . "application/json")
-		("Content-Length" . 0)
-		("X-API-User" . ,habitrpg-api-user)
-		("X-API-Key" . ,habitrpg-api-token))
+     :headers (habitrpg-headers '(("Content-Type" . "application/json")
+				  ("Content-Length" . 0)))
      :parser 'json-read
      :error  (function* (lambda (&key error-thrown &allow-other-keys&rest _)
 			  (message "HabitRPG: Error in getting id for task [%s]" t))))
@@ -1540,9 +1543,7 @@ there.  If its state is DONE, update."
     (deferred:$
       (request-deferred
        (concat habitrpg-api-url habitrpg-api-usertask-path)
-       :headers `(("Accept" . "application/json")
-		  ("X-API-User" . ,habitrpg-api-user)
-		  ("X-API-Key" . ,habitrpg-api-token))
+       :headers (habitrpg-headers '(("Accept" . "application/json")))
        :parser 'json-read
        :error  (function* (lambda (&key error-thrown &allow-other-keys&rest _)
 			    (message "HabitRPG: Error in getting id for task [%s]" ts))))
@@ -1596,10 +1597,8 @@ there.  If its state is DONE, update."
        (concat habitrpg-api-url habitrpg-api-tasks-path "/" id "/score/"
 	       (unless direction "up") direction))
      :type "POST"
-     :headers `(("Content-Type" . "application/json")
-		("Content-Length" . 0)
-		("X-API-User" . ,habitrpg-api-user)
-		("X-API-Key" . ,habitrpg-api-token))
+     :headers (habitrpg-headers '(("Content-Type" . "application/json")
+				  ("Content-Length" . 0)))
      :parser 'json-read
      :success (function* (lambda (&key data &allow-other-keys)
 			   (if hrpg-status-to-file
@@ -1734,9 +1733,7 @@ there.  If its state is DONE, update."
 	(request
 	 (concat habitrpg-api-url habitrpg-api-tasks-path "/" id)
 	 :type "DELETE"
-	 :headers `(("Content-Type" . "application/json")
-		    ("X-API-User" . ,habitrpg-api-user)
-		    ("X-API-Key" . ,habitrpg-api-token))
+	 :headers (habitrpg-headers '(("Content-Type" . "application/json")))
 	 :parser 'json-read
 	 :complete (function*
 		    (lambda (&key data &allow-other-keys)

--- a/habitrpg.el
+++ b/habitrpg.el
@@ -101,6 +101,7 @@
 
 
 (require 'cl)
+(require 'cl-lib)
 (require 'json)
 (unless (require 'deferred nil t)
   (load-file "deferred.el"))
@@ -382,86 +383,89 @@ The function is given one argument, the status buffer."
   (setq header-line-format habitrpg-header-line-string)
   (habitrpg-create-buffer-sections
     (habitrpg-with-section 'status nil
-      (request
-       (concat habitrpg-api-url habitrpg-api-user-path)
-       :type "GET"
-       :parser 'json-read
-       :headers (habitrpg-headers '(("Accept" . "application/json")))
-       :sync t
-       :success (function*
-		 (lambda (&key data &allow-other-keys)
-		   (let* ((data (assoc-default 'data data))
-			  (stats (assoc-default 'stats data))
-			  ;; stats
-			  (exp (assoc-default 'exp stats))
-			  (gp (assoc-default 'gp stats))
-			  (hp (assoc-default 'hp stats))
-			  (maxhp (assoc-default 'maxHealth stats))
-			  (lvl (assoc-default 'lvl stats))
-			  (nextlvl (assoc-default 'toNextLevel stats))
-			  ;; auth info
-			  (auth (assoc-default 'auth data))
-			  (local (assoc-default 'local auth))
-			  (facebook (assoc-default 'facebook auth))
-			  (timestamps (assoc-default 'timestamps auth))
-			  (user (cond
-				 ((assoc-default 'username local))
-				 ((assoc-default 'username facebook))))
-			  (born (assoc-default 'created timestamps))
-			  (uid (assoc-default 'id data))
-			  ;; flags - for inn
-			  (flags (assoc-default 'flags data))
-			  (rest (assoc-default 'rest flags))
-			  ;; pref
-			  (pref (assoc-default 'preferences data))
-			  (day (assoc-default 'dayStart pref)))
-		     (habitrpg-with-section 'stats 'stats
-		       (habitrpg-set-section-info `(("gp" . ,(floor gp))))
-		       (habitrpg-insert-status-line
-			(propertize user 'face 'habitrpg-user)
-			(concat (if (eq rest t)
-				    (propertize "Resting" 'face 'font-lock-warning-face)
-				  "")
-				(propertize
-				 (format " New day starts at %s:00"
-					 (if (stringp day)
-					     (if (eq (string-width day) 1)
-						 (concat "0" day)
-					       day)
-					   (number-to-string day)))
-				 'face 'habitrpg-day)))
+        (request
+         (concat habitrpg-api-url habitrpg-api-user-path)
+         :type "GET"
+         :parser 'json-read
+         :headers (habitrpg-headers '(("Accept" . "application/json")))
+         :sync t
+         :success (function*
+		   (lambda (&key data &allow-other-keys)
+		     (with-current-buffer (or (habitrpg-find-status-buffer 'habitrpg-status-mode)
+					      (get-buffer "*habitrpg:status*")
+					      (current-buffer))
+		       (let* ((data (assoc-default 'data data))
+			      (stats (assoc-default 'stats data))
+			      ;; stats
+			      (exp (assoc-default 'exp stats))
+			      (gp (assoc-default 'gp stats))
+			      (hp (assoc-default 'hp stats))
+			      (maxhp (assoc-default 'maxHealth stats))
+			      (lvl (assoc-default 'lvl stats))
+			      (nextlvl (assoc-default 'toNextLevel stats))
+			      ;; auth info
+			      (auth (assoc-default 'auth data))
+			      (local (assoc-default 'local auth))
+			      (facebook (assoc-default 'facebook auth))
+			      (timestamps (assoc-default 'timestamps auth))
+			      (user (cond
+				     ((assoc-default 'username local))
+				     ((assoc-default 'username facebook))))
+			      (born (assoc-default 'created timestamps))
+			      (uid (assoc-default 'id data))
+			      ;; flags - for inn
+			      (flags (assoc-default 'flags data))
+			      (rest (assoc-default 'rest flags))
+			      ;; pref
+			      (pref (assoc-default 'preferences data))
+			      (day (assoc-default 'dayStart pref)))
+			 (habitrpg-with-section 'stats 'stats
+			   (habitrpg-set-section-info `(("gp" . ,(floor gp))))
+			   (habitrpg-insert-status-line
+			    (propertize user 'face 'habitrpg-user)
+			    (concat (if (eq rest t)
+					(propertize "Resting" 'face 'font-lock-warning-face)
+				      "")
+				    (propertize
+				     (format " New day starts at %s:00"
+					     (if (stringp day)
+						 (if (eq (string-width day) 1)
+						     (concat "0" day)
+						   day)
+					       (number-to-string day)))
+				     'face 'habitrpg-day)))
 
-		       (habitrpg-insert-status-line (concat "Experience: "
-							    (propertize
-							     (number-to-string (floor exp))
-							     'face 'habitrpg-exp))
-						    (propertize (number-to-string nextlvl) 'face 'habitrpg-nextlvl))
-		       (habitrpg-insert-status-line (concat "Gold: "
-							    (propertize (number-to-string (floor gp))
-									'face 'habitrpg-gold)) "")
-		       (habitrpg-insert-status-line (concat "Health: "
-							    (propertize (number-to-string (floor hp))
-									'face 'habitrpg-hp))
-						    (propertize (number-to-string maxhp) 'face 'habitrpg-maxhp))
-		       (habitrpg-insert-status-line (concat "Level: "
-							    (propertize
-							     (number-to-string (floor lvl))
-							     'face 'habitrpg-lvl)) "\n")
-		       (let ((habitrpg-section-hidden-default t))
-			 (habitrpg-with-section uid 'auth
-			   (insert (propertize "[UID]\n" 'face 'font-lock-comment-face))
-			   (insert (propertize (concat uid "\n") 'face 'font-lock-keyword-face)))))))))
-      (insert "\n")
-      (habitrpg-insert-tasks)
-      (habitrpg-insert-habits)
-      (habitrpg-insert-dailys)
-      (habitrpg-insert-rewards)
-      (habitrpg-insert-inventory t)
-      (habitrpg-insert-eggs)
-      (habitrpg-insert-potions)
-      (habitrpg-insert-pets)
-      (habitrpg-insert-store t)
-      (kill-buffer "*request*"))))
+			   (habitrpg-insert-status-line (concat "Experience: "
+								(propertize
+								 (number-to-string (floor exp))
+								 'face 'habitrpg-exp))
+							(propertize (number-to-string nextlvl) 'face 'habitrpg-nextlvl))
+			   (habitrpg-insert-status-line (concat "Gold: "
+								(propertize (number-to-string (floor gp))
+									    'face 'habitrpg-gold)) "")
+			   (habitrpg-insert-status-line (concat "Health: "
+								(propertize (number-to-string (floor hp))
+									    'face 'habitrpg-hp))
+							(propertize (number-to-string maxhp) 'face 'habitrpg-maxhp))
+			   (habitrpg-insert-status-line (concat "Level: "
+								(propertize
+								 (number-to-string (floor lvl))
+								 'face 'habitrpg-lvl)) "\n")
+			   (let ((habitrpg-section-hidden-default t))
+			     (habitrpg-with-section uid 'auth
+			       (insert (propertize "[UID]\n" 'face 'font-lock-comment-face))
+			       (insert (propertize (concat uid "\n") 'face 'font-lock-keyword-face))))))))))
+        (insert "\n")
+        (habitrpg-insert-tasks)
+        (habitrpg-insert-habits)
+        (habitrpg-insert-dailys)
+        (habitrpg-insert-rewards)
+        (habitrpg-insert-inventory t)
+        (habitrpg-insert-eggs)
+        (habitrpg-insert-potions)
+        (habitrpg-insert-pets)
+        (habitrpg-insert-store t)
+        (kill-buffer "*request*"))))
 
 (defun habitrpg-mode ()
   "Review the status of your habitrpg characters.

--- a/habitrpg.el
+++ b/habitrpg.el
@@ -306,6 +306,50 @@ This is an alist where each element is of the
   "List of IDs that need to be upvoted.")
 (defvar hrpg-to-add nil
   "List of tasks that need to be added.")
+
+(cl-defstruct habitrpg-section
+  parent title beginning end children hidden type info
+  needs-refresh-on-show)
+
+;;; Macros
+
+(defmacro habitrpg-with-section (title type &rest body)
+  "Create a new section of title TITLE and type TYPE and evaluate BODY there.
+
+Sections created inside BODY will become children of the new
+section. BODY must leave point at the end of the created section.
+
+If TYPE is nil, the section won't be highlighted."
+  (declare (indent 2))
+  (let ((s (make-symbol "*section*")))
+    `(let* ((,s (habitrpg-new-section ,title ,type))
+            (habitrpg-top-section ,s))
+       (setf (habitrpg-section-beginning ,s) (point))
+       ,@body
+       (setf (habitrpg-section-end ,s) (point))
+       (setf (habitrpg-section-children ,s)
+             (nreverse (habitrpg-section-children ,s)))
+       ,s)))
+
+(defmacro habitrpg-create-buffer-sections (&rest body)
+  "Empty current buffer of text and habitrpg's sections, and then evaluate BODY."
+  (declare (indent 0))
+  `(let ((inhibit-read-only t))
+     (erase-buffer)
+     (let ((habitrpg-old-top-section habitrpg-top-section))
+       (setq habitrpg-top-section nil)
+       ,@body
+       (when (null habitrpg-top-section)
+         (habitrpg-with-section 'top nil
+           (insert "(empty)\n")))
+       (habitrpg-propertize-section habitrpg-top-section)
+       (habitrpg-section-set-hidden habitrpg-top-section
+				    (habitrpg-section-hidden habitrpg-top-section)))))
+
+(defmacro habitrpg-with-refresh (&rest body)
+  (declare (indent 0))
+  `(habitrpg-refresh-wrapper (lambda () ,@body)))
+
 (defvar habitrpg-refresh-function nil)
 (make-variable-buffer-local 'habitrpg-refresh-function)
 (put 'habitrpg-refresh-function 'permanent-local t)
@@ -535,10 +579,6 @@ The function is given one argument, the status buffer."
 ;; represents (if any), and the parent and grand-parent, etc provide
 ;; the context.
 
-(cl-defstruct habitrpg-section
-  parent title beginning end children hidden type info
-  needs-refresh-on-show)
-
 (defvar habitrpg-top-section nil
   "The top section of the current buffer.")
 (make-variable-buffer-local 'habitrpg-top-section)
@@ -576,24 +616,6 @@ The function is given one argument, the status buffer."
 
 (defun habitrpg-set-section-info (info &optional section)
   (setf (habitrpg-section-info (or section habitrpg-top-section)) info))
-
-(defmacro habitrpg-with-section (title type &rest body)
-  "Create a new section of title TITLE and type TYPE and evaluate BODY there.
-
-Sections created inside BODY will become children of the new
-section. BODY must leave point at the end of the created section.
-
-If TYPE is nil, the section won't be highlighted."
-  (declare (indent 2))
-  (let ((s (make-symbol "*section*")))
-    `(let* ((,s (habitrpg-new-section ,title ,type))
-            (habitrpg-top-section ,s))
-       (setf (habitrpg-section-beginning ,s) (point))
-       ,@body
-       (setf (habitrpg-section-end ,s) (point))
-       (setf (habitrpg-section-children ,s)
-             (nreverse (habitrpg-section-children ,s)))
-       ,s)))
 
 (defun habitrpg-set-section-needs-refresh-on-show (flag &optional section)
   (setf (habitrpg-section-needs-refresh-on-show
@@ -687,21 +709,6 @@ See `habitrpg-insert-section' for meaning of the arguments"
 	 habitrpg-api-url
 	 new-request-p
          (append args)))
-
-(defmacro habitrpg-create-buffer-sections (&rest body)
-  "Empty current buffer of text and habitrpg's sections, and then evaluate BODY."
-  (declare (indent 0))
-  `(let ((inhibit-read-only t))
-     (erase-buffer)
-     (let ((habitrpg-old-top-section habitrpg-top-section))
-       (setq habitrpg-top-section nil)
-       ,@body
-       (when (null habitrpg-top-section)
-         (habitrpg-with-section 'top nil
-           (insert "(empty)\n")))
-       (habitrpg-propertize-section habitrpg-top-section)
-       (habitrpg-section-set-hidden habitrpg-top-section
-				    (habitrpg-section-hidden habitrpg-top-section)))))
 
 (defun habitrpg-find-section (path top)
   "Find the section at the path PATH in subsection of section TOP."
@@ -1076,10 +1083,6 @@ buffer's mode doesn't derive from `habitrpg-mode' do nothing."
   (habitrpg-for-all-buffers #'habitrpg-refresh-buffer default-directory))
 
 ;;; Macros
-
-(defmacro habitrpg-with-refresh (&rest body)
-  (declare (indent 0))
-  `(habitrpg-refresh-wrapper (lambda () ,@body)))
 
 (defmacro habitrpg-define-level-shower-1 (level all)
   "Define an interactive function to show function of level LEVEL.

--- a/test-concurrent.el
+++ b/test-concurrent.el
@@ -1,4 +1,4 @@
-;;; test code for concurrent.el
+;;; test-concurrent.el --- test code for concurrent.el  -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2010  SAKURAI Masashi
 ;; Author: SAKURAI Masashi <m.sakurai at kiwanami.net>

--- a/test-deferred.el
+++ b/test-deferred.el
@@ -1,4 +1,4 @@
-;;; test code for deferred.el
+;;; test-deferred.el --- test code for deferred.el  -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2010, 2011  SAKURAI Masashi
 ;; Author: SAKURAI Masashi <m.sakurai at kiwanami.net>

--- a/test-habitrpg.el
+++ b/test-habitrpg.el
@@ -117,5 +117,20 @@
       (when (buffer-live-p other-buf) (kill-buffer other-buf))
       (when (buffer-live-p request-buf) (kill-buffer request-buf)))))
 
+(ert-deftest test-habitrpg-get-id-error ()
+  "Test habitrpg-get-id to reproduce 'it' void variable error."
+  (let ((mock-tasks-data '((data . [((completed . :json-false)
+                                     (type . "todo")
+                                     (text . "test-task")
+                                     (id . "todo-1"))]))))
+    (cl-letf* (((symbol-function 'request)
+                (lambda (url &rest plist)
+                  (let ((complete-cb (plist-get plist :complete))
+                        (mock-response (make-request-response :data mock-tasks-data)))
+                    (funcall complete-cb :response mock-response)))))
+      (should (progn
+                (habitrpg-get-id "test-task" (lambda (id) (message "Id: %s" id)))
+                t)))))
+
 (provide 'test-habitrpg)
 ;;; test-habitrpg.el ends here

--- a/test-habitrpg.el
+++ b/test-habitrpg.el
@@ -1,0 +1,51 @@
+;;; test-habitrpg.el --- Tests for habitrpg.el  -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2026
+;; Author: Ali Ghaffaari <ali.ghaffaari at gmail.com>
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; How to run this test ?
+;; $ Emacs -batch -L . -l test-habitrpg.el -f ert-run-tests-batch-and-exit
+
+;;; Code:
+
+(require 'ert)
+(require 'habitrpg)
+
+(ert-deftest test-habitrpg-headers-default ()
+  "Test that `habitrpg-headers' returns the correct structure by default."
+  (let ((habitrpg-api-user "test-user-id")
+        (habitrpg-api-token "test-token")
+        (habitrpg-api-client "habitrpg"))
+    (let ((headers (habitrpg-headers)))
+      (should (equal (assoc-default "X-API-User" headers) "test-user-id"))
+      (should (equal (assoc-default "X-API-Key" headers) "test-token"))
+      (should (equal (assoc-default "X-Client" headers) "test-user-id-habitrpg")))))
+
+(ert-deftest test-habitrpg-headers-extra ()
+  "Test that extra headers are correctly prepended."
+  (let ((habitrpg-api-user "test-user-id")
+        (habitrpg-api-token "test-token")
+        (habitrpg-api-client "habitrpg"))
+    (let ((headers (habitrpg-headers '(("Accept" . "application/json")))))
+      (should (equal (assoc-default "Accept" headers) "application/json"))
+      (should (equal (assoc-default "X-API-User" headers) "test-user-id"))
+      (should (equal (assoc-default "X-API-Key" headers) "test-token"))
+      (should (equal (assoc-default "X-Client" headers) "test-user-id-habitrpg")))))
+
+(provide 'test-habitrpg)
+;;; test-habitrpg.el ends here

--- a/test-habitrpg.el
+++ b/test-habitrpg.el
@@ -24,6 +24,7 @@
 ;;; Code:
 
 (require 'ert)
+(require 'cl-lib)
 (require 'habitrpg)
 
 (ert-deftest test-habitrpg-headers-default ()
@@ -46,6 +47,75 @@
       (should (equal (assoc-default "X-API-User" headers) "test-user-id"))
       (should (equal (assoc-default "X-API-Key" headers) "test-token"))
       (should (equal (assoc-default "X-Client" headers) "test-user-id-habitrpg")))))
+
+(ert-deftest test-habitrpg-refresh-status ()
+  "Test that `habitrpg-refresh-status` runs without throwing an error."
+  (let ((status-buf (generate-new-buffer "*habitrpg:status*"))
+        (other-buf (generate-new-buffer "*other-buffer*"))
+        (request-buf (get-buffer-create "*request*"))
+        (mock-user-data '((data . ((stats . ((exp . 10)
+                                              (gp . 15.5)
+                                              (hp . 50)
+                                              (maxHealth . 50)
+                                              (lvl . 3)
+                                              (toNextLevel . 100)))
+                                    (auth . ((local . ((username . "test-username")))))
+                                    (id . "test-uid")
+                                    (flags . ((rest . :json-false)))
+                                    (preferences . ((dayStart . 0)))
+                                    (items . ((eggs . ((wolf . 1)))
+                                              (hatchingPotions . ((base . 1)))
+                                              (pets . ((wolf-base . t)))))))))
+        (mock-tasks-data '((data . [((completed . :json-false)
+                                     (type . "todo")
+                                     (text . "test-todo")
+                                     (id . "todo-1")
+                                     (value . 0)
+                                     (notes . "todo notes"))
+                                    ((completed . :json-false)
+                                     (type . "habit")
+                                     (text . "test-habit")
+                                     (id . "habit-1")
+                                     (value . 2)
+                                     (notes . "habit notes"))
+                                    ((completed . :json-false)
+                                     (type . "daily")
+                                     (text . "test-daily")
+                                     (id . "daily-1")
+                                     (value . 0)
+                                     (notes . "daily notes"))
+                                    ((completed . :json-false)
+                                     (type . "reward")
+                                     (text . "test-reward")
+                                     (id . "reward-1")
+                                     (value . 10)
+                                     (notes . "reward notes"))])))
+        (mock-store-data '((data . [((key . "potion-base") (value . 15))]))))
+    (unwind-protect
+        (with-current-buffer status-buf
+          (habitrpg-status-mode)
+          ;; Mock request function
+          (cl-letf (((symbol-function 'request)
+                     (lambda (url &rest plist)
+                       (let ((success-cb (plist-get plist :success))
+                             (data (cond
+                                    ((string-suffix-p habitrpg-api-usertask-path url)
+                                     mock-tasks-data)
+                                    ((string-suffix-p (concat habitrpg-api-inventory-path "/buy") url)
+                                     mock-store-data)
+                                    ((string-suffix-p habitrpg-api-user-path url)
+                                     mock-user-data)
+                                    (t (error "Unknown mock URL: %s" url)))))
+                         ;; Switch to other-buf to simulate request's callback execution context
+                         (with-current-buffer other-buf
+                           (funcall success-cb :data data))))))
+            ;; Executing habitrpg-refresh-status should succeed and not throw error
+            (should (progn
+                      (habitrpg-refresh-status)
+                      t))))
+      (when (buffer-live-p status-buf) (kill-buffer status-buf))
+      (when (buffer-live-p other-buf) (kill-buffer other-buf))
+      (when (buffer-live-p request-buf) (kill-buffer request-buf)))))
 
 (provide 'test-habitrpg)
 ;;; test-habitrpg.el ends here


### PR DESCRIPTION
This PR fixes five issues:
1. First, it refactors the request headers construction across habitrpg.el into a new `habitrpg-headers` helper. This helper automatically appends the mandatory X-Client header, resolving the 403 Forbidden / 400 Bad Request errors from the server. Also add/polish ERT unit tests to verify correct header generation.

2. Second, it fixes the process sentinel error when calling `habitrpg-status` by wrapping the body of the request success callback in a:

```lisp
(with-current-buffer (or (habitrpg-find-status-buffer 'habitrpg-status-mode)
      (get-buffer "*habitrpg:status*")
      (current-buffer))
  ;; BODY
)
```
3. Moreover, it fixes the error `Symbol's value as variable is void: it` that occurred when calling `habitrpg-get-id`
4. It also reorders some macros to resolve 'macro defined too late' warnings.
5. In addition, it fixes the header lines in test-* files.